### PR TITLE
fix(behavior_path_planner): prevent segfault in updateBoundary with index validation

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -619,6 +619,11 @@ std::vector<Point> updateBoundary(
       0 < front_offset ? start_poly.bound_seg_idx + 1 : start_poly.bound_seg_idx;
     const size_t removed_end_idx = end_poly.bound_seg_idx;
 
+    if (removed_start_idx > removed_end_idx || removed_end_idx >= updated_bound.size()) {
+      RCLCPP_WARN(logger, "Invalid index for erase in updateBoundary. Skipping.");
+      continue;
+    }
+
     updated_bound.erase(
       updated_bound.begin() + removed_start_idx, updated_bound.begin() + removed_end_idx + 1);
 


### PR DESCRIPTION
## Description

This PR addresses a critical segmentation fault that occurs in the `behavior_path_planner`, specifically within the static obstacle avoidance module. The crash happens during the process of modifying the drivable area boundary when multiple static obstacles are present, causing the `component_container_mt` process to die.

#### Stack Trace of the Crash

The crash is identified by the following stack trace, which points to an issue within the `updateBoundary` function.

```
[component_container_mt-94] malloc(): invalid size (unsorted)
[component_container_mt-94] *** Aborted at 1750213214 (unix time) try "date -d @1750213214" if you are using GNU date ***
[component_container_mt-94] PC: @                0x0 (unknown)
[component_container_mt-94] *** SIGABRT (@0x3e800001dd0) received by PID 7632 (TID 0x7f81e0ff1640) from PID 7632; stack trace: ***
[component_container_mt-94]     @     0x7f820b19e4d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-94]     @     0x7f820a642520 (unknown)
[component_container_mt-94]     @     0x7f820a6969fc pthread_kill
[component_container_mt-94]     @     0x7f820a642476 raise
[component_container_mt-94]     @     0x7f820a6287f3 abort
[component_container_mt-94]     @     0x7f820a689677 (unknown)
[component_container_mt-94]     @     0x7f820a6a0cfc (unknown)
[component_container_mt-94]     @     0x7f820a6a40dc (unknown)
[component_container_mt-94]     @     0x7f820a6a5139 malloc
[component_container_mt-94]     @     0x7f820aaae98c operator new()
[component_container_mt-94]     @     0x7f81dd792a4e std::vector<>::reserve()
[component_container_mt-94]     @     0x7f81dd795004 autoware::motion_utils::removeOverlapPoints<>()
[component_container_mt-94]     @     0x7f81dd795426 autoware::motion_utils::calcLongitudinalOffsetToSegment<>()
[component_container_mt-94]     @     0x7f81dd7779f9 autoware::behavior_path_planner::utils::drivable_area_processing::updateBoundary()
[component_container_mt-94]     @     0x7f81dd7788d6 autoware::behavior_path_planner::utils::extractObstaclesFromDrivableArea()
[component_container_mt-94]     @     0x7f81dc86ecb2 autoware::behavior_path_planner::utils::static_obstacle_avoidance::updateRoadShoulderDistance()
[component_container_mt-94]     @     0x7f81dc827cc2 autoware::behavior_path_planner::StaticObstacleAvoidanceModule::fillAvoidanceTargetObjects()
[component_container_mt-94]     @     0x7f81dc8299cb autoware::behavior_path_planner::StaticObstacleAvoidanceModule::fillFundamentalData()
[component_container_mt-94]     @     0x7f81dc82a855 autoware::behavior_path_planner::StaticObstacleAvoidanceModule::updateData()
[component_container_mt-94]     @     0x7f81ddd6b27a autoware::behavior_path_planner::SceneModuleManagerInterface::isExecutionRequested()
[component_container_mt-94]     @     0x7f81ddd465b6 autoware::behavior_path_planner::SubPlannerManager::getRequestModules()
[component_container_mt-94]     @     0x7f81ddd5105e autoware::behavior_path_planner::SubPlannerManager::propagateFull()
[component_container_mt-94]     @     0x7f81ddd53578 autoware::behavior_path_planner::PlannerManager::run()
[component_container_mt-94]     @     0x7f81dddac05e autoware::behavior_path_planner::BehaviorPathPlannerNode::run()
[component_container_mt-94]     @     0x7f81dddb43d5 rclcpp::GenericTimer<>::execute_callback()
[component_container_mt-94]     @     0x7f820af5effe rclcpp::Executor::execute_any_executable()
[component_container_mt-94]     @     0x7f820af65432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-94]     @     0x7f820aadc253 (unknown)
[component_container_mt-94]     @     0x7f820a694ac3 (unknown)
[component_container_mt-94]     @     0x7f820a726850 (unknown)
[ERROR] [component_container_mt-94]: process has died [pid 7632, exit code -6, cmd '/home/autoware/autoware.proj/install/rclcpp_components/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=False -p wheel_radius:=0.3725 -p wheel_width:=0.215 -p wheel_base:=4.76012 -p wheel_tread:=1.754 -p front_overhang:=0.95099 -p rear_overhang:=1.52579 -p left_overhang:=0.26878 -p right_overhang:=0.26878 -p vehicle_height:=3.08 -p max_steer_angle:=0.64'].
...
```

#### Root Cause Analysis

The root cause of the segmentation fault lies in the `updateBoundary` function located in `drivable_area_expansion/static_drivable_area.cpp`.

This function modifies the drivable area's boundary (`updated_bound`) by iterating through a list of obstacle polygons and removing sections of the boundary vector using `std::vector::erase()`.

The core of the problem is as follows:
1.  The function iterates over obstacle polygons, each containing segment indices (`bound_seg_idx`) that were calculated based on the **original** boundary's state before any modifications.
2.  Inside the loop, `updated_bound.erase()` is called, which shrinks the size of the `updated_bound` vector.
3.  In subsequent iterations, the pre-calculated indices from other obstacle polygons can become invalid (i.e., out of bounds) for the now-smaller `updated_bound` vector.
4.  Calling `erase()` with iterators derived from these out-of-bounds indices results in undefined behavior, leading to the observed segmentation fault.

#### Solution

To resolve this issue, this PR introduces a guard clause to validate the indices right before calling `updated_bound.erase()`.

This check ensures that both the start and end indices for the erase operation are within the valid range of the `updated_bound` vector's current size. If the indices are invalid, the operation for that particular polygon is skipped, and an error is logged. This prevents the crash while maintaining the integrity of the drivable area generation process.



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
